### PR TITLE
Nouvelle implementation du zoom

### DIFF
--- a/src/android/customCamera/res/layout/activity_camera_view.xml
+++ b/src/android/customCamera/res/layout/activity_camera_view.xml
@@ -95,5 +95,13 @@
                 android:layout_weight="1"
                 android:text="@string/declinePicture" />
         </LinearLayout>
+
     </FrameLayout>
+
+    <SeekBar
+        android:id="@+id/niveauZoom"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="visible" />
+
 </RelativeLayout>


### PR DESCRIPTION
Après discussion avec Jérôme:

_ Pour la première version de l'application et surtout pour faire les tests, on fait le zoom avec une barre car le zoom avec les doigts est encore un peu bugué.

_ En effet, le zoom avec les doigts marche (zoom avant ET zoom arrière) mais est lent (du certainement aux recalculs successifs du nouveau niveau de zoom). De plus, le zoom ne marche pas pareil sur tous les appareils (peut-être du aux différentes résolutions. Par exemple, pour la tablette ASUS qui n'a pas une grande résolution, le zoom passe presque tout de suite de 0 à 100% alors qu'on ne bouge que de quelques pixels les doigts. Pour le même écart de doigts, le nexus n'augmentera que d'un niveau de zoom).

Les deux types de zoom sont présents sur l'application pour le moment mais on préférera utiliser la barre pour tester. Il faudra donc revoir celui aux doigts dans les prochaines MaJ. (recréer une issue ? )
